### PR TITLE
Fix CI coverage test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ addons:
     - binutils-dev
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo --only stable doc-upload; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo; fi
-#- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/version*compare-*; fi
+# - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --verify --no-sudo; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/deps/version*compare-*; fi
 env:
   global:
   - TRAVIS_CARGO_NIGHTLY_FEATURE=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,36 @@ before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
+
 script:
 - |
   travis-cargo build &&
   travis-cargo test &&
   travis-cargo bench &&
   travis-cargo --only stable doc
+
 addons:
   apt:
     packages:
     - libcurl4-openssl-dev
     - libelf-dev
     - libdw-dev
+    - cmake
+    - gcc
     - binutils-dev
+
+# Upload test coverage
+# TODO: Update documentation
 after_success:
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo --only stable doc-upload; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --verify --no-sudo; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/deps/version*compare-*; fi
-env:
-  global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=dev
+- |
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/version*compare-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,6 @@ after_success:
   sudo make install &&
   cd ../.. &&
   rm -rf kcov-master &&
-  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/version*compare-*
+  cargo clean &&
+  cargo test --no-run &&
+  for file in target/debug/version_compare-*; do mkdir -p "target/cov/$(basename $file)"; kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
     - binutils-dev
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo --only stable doc-upload; fi
-# - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --verify --no-sudo; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --verify --no-sudo; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/deps/version*compare-*; fi
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ after_success:
   rm -rf kcov-master &&
   cargo clean &&
   cargo test --no-run &&
-  for file in target/debug/version_compare-*; do mkdir -p "target/cov/$(basename $file)"; kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done
+  for file in target/debug/version_compare-*; do mkdir -p "target/cov/$(basename $file)"; kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; break; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,10 @@ rust:
   - beta
   - nightly
 
-# Documentation generation, and coverage data
-before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
-
 script:
 - |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo --only stable doc
+  cargo build &&
+  cargo test
 
 addons:
   apt:
@@ -43,7 +36,3 @@ after_success:
   cd ../.. &&
   rm -rf kcov-master &&
   kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/version*compare-*
-
-env:
-  global:
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ addons:
     - binutils-dev
 after_success:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo --only stable doc-upload; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo --verify; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --verify --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/version*compare-*; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis-cargo coveralls --no-sudo; fi
+#- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./kcov/build/src/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/version*compare-*; fi
 env:
   global:
   - TRAVIS_CARGO_NIGHTLY_FEATURE=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ after_success:
   cd build &&
   cmake .. &&
   make &&
-  sudo make install &&
+  make install &&
   cd ../.. &&
   rm -rf kcov-master &&
   kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/version*compare-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Configuration for Travis CI
 language: rust
-sudo: false
+sudo: true
 rust:
   - stable
   - beta
@@ -40,7 +40,7 @@ after_success:
   cd build &&
   cmake .. &&
   make &&
-  make install &&
+  sudo make install &&
   cd ../.. &&
   rm -rf kcov-master &&
   kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/version*compare-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
 - |
   travis-cargo build &&
   travis-cargo test &&
-  travis-cargo bench &&
   travis-cargo --only stable doc
 
 addons:
@@ -44,3 +43,7 @@ after_success:
   cd ../.. &&
   rm -rf kcov-master &&
   kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,/usr/lib --verify target/cov target/debug/version*compare-*
+
+env:
+  global:
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=dev

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 # Rust library: version-compare
 > A Rust library to easily compare version numbers, and test them against various comparison operators.
 
-[Documentation](https://timvisee.github.io/version-compare)
+[Documentation](https://docs.rs/version-compare)
 
 Comparing version numbers is hard. Especially when version numbers get really complex,
 or when their formatting differs. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status on Travis CI](https://travis-ci.org/timvisee/version-compare.svg?branch=master)](https://travis-ci.org/timvisee/version-compare)
 [![Library on crates.io](https://img.shields.io/crates/v/version-compare.svg)](https://crates.io/crates/version-compare)
 [![Download statistics on crates.io](https://img.shields.io/crates/d/version-compare.svg)](https://crates.io/crates/version-compare)
+[![Coverage Status](https://coveralls.io/repos/github/timvisee/version-compare/badge.svg?branch=master)](https://coveralls.io/github/timvisee/version-compare?branch=master)
 [![Dependencies on libraries.io](https://img.shields.io/badge/dependencies-none!-brightgreen.svg)](https://libraries.io/github/timvisee/version-compare)
 [![Library on crates.io](https://img.shields.io/crates/l/version-compare.svg)](https://crates.io/crates/version-compare)
 


### PR DESCRIPTION
Fix the testing method used on Travis CI, as there were some problems with coverage data and documentation.

* Fix test coverage data being invalid.
* The documentation is now hosted on [docs.rs](https://docs.rs/version-compare/).
* Added coverage badge in README back.