### PR TITLE
Version 0.0.5, two additional comparison operator signs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "version-compare"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["timvisee <timvisee@gmail.com>"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This library is very easy to use. Here's a basic usage example:
 Cargo.toml:
 ```toml
 [dependencies]
-version-compare = "0.0.4"
+version-compare = "0.0.5"
 ```
 
 [main.rs:](examples/example.rs)

--- a/src/comp_op.rs
+++ b/src/comp_op.rs
@@ -44,8 +44,8 @@ impl CompOp {
     ///
     /// The following signs are supported:
     ///
-    /// * `==` -> `Eq`
-    /// * `!=` -> `Ne`
+    /// * `==` _or_ `=` -> `Eq`
+    /// * `!=` _or_ `!` -> `Ne`
     /// * `< ` -> `Lt`
     /// * `<=` -> `Le`
     /// * `>=` -> `Ge`
@@ -63,8 +63,8 @@ impl CompOp {
     /// ```
     pub fn from_sign(sign: &str) -> Result<CompOp, ()> {
         match sign.trim().as_ref() {
-            "==" => Ok(CompOp::Eq),
-            "!=" => Ok(CompOp::Ne),
+            "==" | "=" => Ok(CompOp::Eq),
+            "!=" | "!" => Ok(CompOp::Ne),
             "<" => Ok(CompOp::Lt),
             "<=" => Ok(CompOp::Le),
             ">=" => Ok(CompOp::Ge),
@@ -293,6 +293,10 @@ impl CompOp {
     /// * `Ge` -> `>=`
     /// * `Gt` -> `> `
     ///
+    /// Note: Some comparison operators also support other signs,
+    /// such as `=` for `Eq` and `!` for `Ne`,
+    /// these are never returned by this method however as the table above is used.
+    ///
     /// # Examples
     ///
     /// ```
@@ -381,7 +385,9 @@ mod tests {
     fn from_sign() {
         // Normal signs
         assert_eq!(CompOp::from_sign("==").unwrap(), CompOp::Eq);
+        assert_eq!(CompOp::from_sign("=").unwrap(), CompOp::Eq);
         assert_eq!(CompOp::from_sign("!=").unwrap(), CompOp::Ne);
+        assert_eq!(CompOp::from_sign("!").unwrap(), CompOp::Ne);
         assert_eq!(CompOp::from_sign("<").unwrap(), CompOp::Lt);
         assert_eq!(CompOp::from_sign("<=").unwrap(), CompOp::Le);
         assert_eq!(CompOp::from_sign(">=").unwrap(), CompOp::Ge);


### PR DESCRIPTION
A minor update to add two additional comparison operator signs.

* `=` -> `CompOp::Eq`
* `!` -> `CompOp::Ne`