### PR TITLE
fix nightly lifetime warning

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -307,7 +307,7 @@ impl<'a> Version<'a> {
     /// assert_eq!(Version::from("0.3.0.0").unwrap().compare(&Version::from("0.3").unwrap()), CompOp::Eq);
     /// assert_eq!(Version::from("2").unwrap().compare(&Version::from("1.7.3").unwrap()), CompOp::Gt);
     /// ```
-    pub fn compare(&self, other: &Version) -> CompOp {
+    pub fn compare(&self, other: &'a Version) -> CompOp {
         // Compare the versions with their peekable iterators
         Self::compare_iter(self.parts.iter().peekable(), other.parts.iter().peekable())
     }


### PR DESCRIPTION
just gits rid of a small warning on nightly that will be an error at some point

```
= warning: this error has been downgraded to a warning for backwards compatibility with previous releases
= warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
```
    