### PR TITLE
Show failing assertion case in comparisons

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -662,7 +662,9 @@ mod tests {
             let version_b = Version::from(&entry.1).unwrap();
 
             // Compare them
-            assert_eq!(version_a.compare(&version_b), entry.2.clone());
+            assert_eq!(version_a.compare(&version_b), entry.2.clone(),
+                       "Testing that {} is {} {}", &entry.0, &entry.2.sign(), &entry.1
+            );
         }
     }
 

--- a/src/version_compare.rs
+++ b/src/version_compare.rs
@@ -93,7 +93,8 @@ mod tests {
         for entry in TEST_VERSION_SETS {
             assert_eq!(
                 VersionCompare::compare(&entry.0, &entry.1),
-                Ok(entry.2.clone())
+                Ok(entry.2.clone()),
+                "Testing that {} is {} {}", &entry.0, &entry.2.sign(), &entry.1
             );
         }
 


### PR DESCRIPTION
The collection approach is great for reuse of the test cases, but
obfuscates which test case is failing.  Hopefully this helps show
which case needs examination.

Signed-off-by: Michael Sarahan <msarahan@gmail.com>