### PR TITLE
Epoch operator

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -40,6 +40,16 @@ pub struct Manifest {
     ///
     /// Issue: https://github.com/timvisee/version-compare/issues/27
     pub gnu_ordering: bool,
+
+    /// Support Python style version epochs.
+    /// If `true` and no epoch is specified, it will assume everything is prefixed by `0!`.
+    /// Examples:
+    /// `0!1.2.1` == `1.2.1`
+    /// `1!0.2.1` > `1.2.1`
+    ///
+    /// For details see:
+    /// https://peps.python.org/pep-0440/#version-epochs
+    pub epoch: bool,
 }
 
 /// Version manifest implementation.

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,7 @@ const MANIFEST_GNU: Option<Manifest> = Some(Manifest {
     epoch: false,
 });
 
-/// A manifest configuration for GNU versions.
+/// A manifest configuration for Python versions possibly containing an epoch.
 const MANIFEST_PYTHON: Option<Manifest> = Some(Manifest {
     gnu_ordering: true,
     max_depth: None,

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,6 +5,15 @@ const MANIFEST_GNU: Option<Manifest> = Some(Manifest {
     gnu_ordering: true,
     max_depth: None,
     ignore_text: false,
+    epoch: false,
+});
+
+/// A manifest configuration for GNU versions.
+const MANIFEST_PYTHON: Option<Manifest> = Some(Manifest {
+    gnu_ordering: true,
+    max_depth: None,
+    ignore_text: false,
+    epoch: true,
 });
 
 /// Struct containing a version number with some meta data.
@@ -157,9 +166,9 @@ pub const COMBIS: &[VersionCombi] = &[
     VersionCombi("snapshot.1.2.3", "1.2.3.alpha", Cmp::Lt, None),
     VersionCombi("snapshot-1.2.3", "1.2.3-alpha", Cmp::Lt, None),
     // Version Epoch as defined by Python's PEP440 https://peps.python.org/pep-0440/#version-epochs
-    VersionCombi("0!0.0.1", "0.0.1", Cmp::Eq, None),
-    VersionCombi("1!1.2.1", "0!1.2.1", Cmp::Gt, None),
-    VersionCombi("0!2.1.2", "1!0.2.1", Cmp::Lt, None),
+    VersionCombi("0!0.0.1", "0.0.1", Cmp::Eq, MANIFEST_PYTHON),
+    VersionCombi("1!1.2.1", "0!1.2.1", Cmp::Gt, MANIFEST_PYTHON),
+    VersionCombi("0!2.1.2", "1!0.2.1", Cmp::Lt, MANIFEST_PYTHON),
 ];
 
 /// List of invalid version combinations for dynamic tests

--- a/src/test.rs
+++ b/src/test.rs
@@ -40,6 +40,9 @@ pub const VERSIONS: &[Version] = &[
     Version("0.0.1-test.0222426166565421816516584651684351354", 5),
     Version("0.0.1-test.02224261665a", 5),
     Version("0.0.1-test.02224261665d7b1b689816d12f6bcacb", 5),
+    // Version Epoch as defined by Python's PEP440 https://peps.python.org/pep-0440/#version-epochs
+    Version("0!0.0.1-test.02224261665d7b1b689816d12f6bcacb", 6),
+    Version("1!1.2.1", 4),
 ];
 
 /// List of version numbers that contain errors with metadata for dynamic tests
@@ -153,6 +156,10 @@ pub const COMBIS: &[VersionCombi] = &[
     // TODO: inspect these cases
     VersionCombi("snapshot.1.2.3", "1.2.3.alpha", Cmp::Lt, None),
     VersionCombi("snapshot-1.2.3", "1.2.3-alpha", Cmp::Lt, None),
+    // Version Epoch as defined by Python's PEP440 https://peps.python.org/pep-0440/#version-epochs
+    VersionCombi("0!0.0.1", "0.0.1", Cmp::Eq, None),
+    VersionCombi("1!1.2.1", "0!1.2.1", Cmp::Gt, None),
+    VersionCombi("0!2.1.2", "1!0.2.1", Cmp::Lt, None),
 ];
 
 /// List of invalid version combinations for dynamic tests

--- a/src/version.rs
+++ b/src/version.rs
@@ -326,6 +326,12 @@ fn split_version_str<'a>(
         used_manifest = m;
     }
 
+    // If we are doing the python style versions, inject an implicit epoch, unless already
+    // specified
+    if used_manifest.epoch && !version.contains('!') {
+        parts.push(Part::Number(0))
+    }
+
     // Loop over the parts, and parse them
     for part in split {
         // We may not go over the maximum depth


### PR DESCRIPTION
This adds support for the Python style version Epochs.

These are intended to allow developers to change their versioning scheme but also still maintain version ordering. More details here: https://peps.python.org/pep-0440/#version-epochs

I implemented this by adding a new `Manifest` option called `epoch: bool` and then adding logic to the `fn split_version_str()` to check for the presence of that epoch manifest option and inject a default manifest version of `0` if necessary.